### PR TITLE
[3.0.r1] thermal-hal: Add support for parrot configuration

### DIFF
--- a/thermalConfig.cpp
+++ b/thermalConfig.cpp
@@ -1040,6 +1040,80 @@ namespace thermal {
 		},
 	};
 
+	std::vector<std::string> cpu_sensors_parrot =
+	{
+		"cpu-0-0",
+		"cpu-0-1",
+		"cpu-0-2",
+		"cpu-0-3",
+		"cpu-1-0",
+		"cpu-1-2",
+		"cpu-1-4",
+		"cpu-1-6",
+	};
+
+	std::vector<struct target_therm_cfg>  parrot_common = {
+		{
+			TemperatureType::CPU,
+			cpu_sensors_parrot,
+			"",
+			95000,
+			115000,
+			true,
+		},
+		{
+			TemperatureType::GPU,
+			{ "gpuss-0" },
+			"GPU0",
+			95000,
+			115000,
+			true,
+		},
+		{
+			TemperatureType::GPU,
+			{ "gpuss-1" },
+			"GPU1",
+			95000,
+			115000,
+			true,
+		},
+		{
+			TemperatureType::NPU,
+			{ "nspss-0" },
+			"nsp0",
+			95000,
+			115000,
+			true,
+		},
+		{
+			TemperatureType::NPU,
+			{ "nspss-1" },
+			"nsp1",
+			95000,
+			115000,
+			true,
+		},
+	};
+
+	std::vector<struct target_therm_cfg>  parrot_specific = {
+		{
+			TemperatureType::BCL_CURRENT,
+			{ "pm7250b-ibat-lvl0" },
+			"ibat",
+			6000,
+			7500,
+			true,
+		},
+		{
+			TemperatureType::SKIN,
+			{ "xo-therm" },
+			"skin",
+			55000,
+			95000,
+			true,
+		},
+	};
+
 	struct target_therm_cfg bat_conf = {
 		TemperatureType::BATTERY,
 		{ "battery" },
@@ -1872,6 +1946,7 @@ std::vector<std::string> cpu_sensors_cliffs = {
 		{658, volcano_specific}, //milos IOT
 		{549, anorak_common},
 		{649, anorak_common}, // Halliday Pro
+		{537, parrot_common},
 	};
 
 	const std::unordered_map<int, std::vector<struct target_therm_cfg>>
@@ -1907,6 +1982,7 @@ std::vector<std::string> cpu_sensors_cliffs = {
 		{640, volcano_specific}, //milos6
 		{549, anorak_specific},
 		{649, anorak_specific}, // Halliday Pro
+		{537, parrot_specific},
 	};
 
 	const std::unordered_map<int, bool>


### PR DESCRIPTION
Add support for parrot configuration to include all the CPU, GPU, NSP,
skin, battery and BCL configurations.